### PR TITLE
Fix MahApps.Metro usage

### DIFF
--- a/SixNations/SixNations.Desktop/App.xaml
+++ b/SixNations/SixNations.Desktop/App.xaml
@@ -1,11 +1,12 @@
-<Application x:Class="SixNations.Desktop.App" 
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-             xmlns:vm="clr-namespace:SixNations.Desktop.ViewModels" 
-             Startup="Application_Startup" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             d1p1:Ignorable="d" 
-             xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">
+<Application x:Class="SixNations.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:SixNations.Desktop.ViewModels"
+             Startup="Application_Startup"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             d1p1:Ignorable="d"
+             xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -15,6 +16,10 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Steel.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <Style TargetType="{x:Type mah:WindowButtonCommands}"
+                   BasedOn="{StaticResource MahApps.Metro.Styles.WindowButtonCommands.Win10}" />
+
             <vm:ViewModelLocator x:Key="Locator" d:IsDataSource="True" />
         </ResourceDictionary>
     </Application.Resources>

--- a/SixNations/SixNations.Desktop/App.xaml
+++ b/SixNations/SixNations.Desktop/App.xaml
@@ -8,6 +8,13 @@
              xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">
     <Application.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Steel.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+            </ResourceDictionary.MergedDictionaries>
             <vm:ViewModelLocator x:Key="Locator" d:IsDataSource="True" />
         </ResourceDictionary>
     </Application.Resources>

--- a/SixNations/SixNations.Desktop/Views/AboutDialog.xaml
+++ b/SixNations/SixNations.Desktop/Views/AboutDialog.xaml
@@ -1,10 +1,11 @@
-﻿<Window x:Class="SixNations.Desktop.Views.AboutDialog"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:controls="clr-namespace:SixNations.Desktop.Controls"
-        mc:Ignorable="d"
-        Title="About SixNations.Desktop" Height="480" Width="640">
-    <controls:About/>
-</Window>
+﻿<mah:MetroWindow x:Class="SixNations.Desktop.Views.AboutDialog"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:controls="clr-namespace:SixNations.Desktop.Controls"
+                 xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                 mc:Ignorable="d"
+                 Title="About SixNations.Desktop" Height="480" Width="640">
+    <controls:About />
+</mah:MetroWindow>

--- a/SixNations/SixNations.Desktop/Views/MainWindow.xaml
+++ b/SixNations/SixNations.Desktop/Views/MainWindow.xaml
@@ -1,24 +1,24 @@
-﻿<Window x:Class="SixNations.Desktop.Views.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-        xmlns:system="clr-namespace:System;assembly=mscorlib"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:SixNations.Desktop.Views"
-        xmlns:vm="clr-namespace:SixNations.Desktop.ViewModels"
-        xmlns:controls="clr-namespace:SixNations.Desktop.Controls"
-        xmlns:mahapps="http://metro.mahapps.com/winfx/xaml/controls"
-        xmlns:md="https://github.com/fantasticfiasco/mvvm-dialogs"
-        md:DialogServiceViews.IsRegistered="True"
-        mc:Ignorable="d"
-        Title="Six Nations"
-        Height="600" Width="900"
-        WindowState="Normal"
-        DataContext="{Binding Source={StaticResource Locator}, Path=Main}">
-    
+﻿<mah:MetroWindow x:Class="SixNations.Desktop.Views.MainWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:system="clr-namespace:System;assembly=mscorlib"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:local="clr-namespace:SixNations.Desktop.Views"
+                 xmlns:vm="clr-namespace:SixNations.Desktop.ViewModels"
+                 xmlns:controls="clr-namespace:SixNations.Desktop.Controls"
+                 xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                 xmlns:md="https://github.com/fantasticfiasco/mvvm-dialogs"
+                 md:DialogServiceViews.IsRegistered="True"
+                 mc:Ignorable="d"
+                 Title="Six Nations"
+                 Height="600" Width="900"
+                 WindowState="Normal"
+                 DataContext="{Binding Source={StaticResource Locator}, Path=Main}">
+
     <Window.Resources>
-        <DataTemplate x:Key="MenuItemTemplate" 
-                      DataType="{x:Type mahapps:HamburgerMenuGlyphItem}">
+        <DataTemplate x:Key="MenuItemTemplate"
+                      DataType="{x:Type mah:HamburgerMenuGlyphItem}">
             <Grid Height="48">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="48" />
@@ -41,17 +41,17 @@
     </Window.Resources>
 
     <DockPanel>
-        <mahapps:HamburgerMenu x:Name="HamburgerNav"
-                               PaneBackground="#FF444444"
-                               IsPaneOpen="False" 
-                               DisplayMode="CompactInline"
-                               ItemTemplate="{StaticResource MenuItemTemplate}"
-                               OptionsItemTemplate="{StaticResource MenuItemTemplate}"
-                               ItemClick="HamburgerNav_ItemClick"
-                               OptionsItemClick="HamburgerNav_ItemClick">
+        <mah:HamburgerMenu x:Name="HamburgerNav"
+                           PaneBackground="#FF444444"
+                           IsPaneOpen="False"
+                           DisplayMode="CompactInline"
+                           ItemTemplate="{StaticResource MenuItemTemplate}"
+                           OptionsItemTemplate="{StaticResource MenuItemTemplate}"
+                           ItemClick="HamburgerNav_ItemClick"
+                           OptionsItemClick="HamburgerNav_ItemClick">
 
-            <mahapps:HamburgerMenu.ContentTemplate>
-                <DataTemplate DataType="{x:Type mahapps:HamburgerMenuItem}">
+            <mah:HamburgerMenu.ContentTemplate>
+                <DataTemplate DataType="{x:Type mah:HamburgerMenuItem}">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="48" />
@@ -73,38 +73,38 @@
                                         Content="{Binding Tag}" />
                     </Grid>
                 </DataTemplate>
-            </mahapps:HamburgerMenu.ContentTemplate>
-            
-            <mahapps:HamburgerMenu.ItemsSource>
-                <mahapps:HamburgerMenuItemCollection>
+            </mah:HamburgerMenu.ContentTemplate>
 
-                    <mahapps:HamburgerMenuGlyphItem Glyph="&#xE72E;" Label="Login">
-                        <mahapps:HamburgerMenuGlyphItem.Tag>
-                            <controls:Login/>
-                        </mahapps:HamburgerMenuGlyphItem.Tag>
-                    </mahapps:HamburgerMenuGlyphItem>
-                    
-                </mahapps:HamburgerMenuItemCollection>
-            </mahapps:HamburgerMenu.ItemsSource>
+            <mah:HamburgerMenu.ItemsSource>
+                <mah:HamburgerMenuItemCollection>
 
-            <mahapps:HamburgerMenu.OptionsItemsSource>
-                <mahapps:HamburgerMenuItemCollection>
+                    <mah:HamburgerMenuGlyphItem Glyph="&#xE72E;" Label="Login">
+                        <mah:HamburgerMenuGlyphItem.Tag>
+                            <controls:Login />
+                        </mah:HamburgerMenuGlyphItem.Tag>
+                    </mah:HamburgerMenuGlyphItem>
 
-                    <mahapps:HamburgerMenuGlyphItem Glyph="&#xE9CE;" Label="About">
-                        <mahapps:HamburgerMenuGlyphItem.Tag>
-                            <controls:About/>
-                        </mahapps:HamburgerMenuGlyphItem.Tag>
-                    </mahapps:HamburgerMenuGlyphItem>
+                </mah:HamburgerMenuItemCollection>
+            </mah:HamburgerMenu.ItemsSource>
 
-                    <mahapps:HamburgerMenuGlyphItem Glyph="&#xE713;" Label="Settings">
-                        <mahapps:HamburgerMenuGlyphItem.Tag>
-                            <controls:Settings/>
-                        </mahapps:HamburgerMenuGlyphItem.Tag>
-                    </mahapps:HamburgerMenuGlyphItem>
+            <mah:HamburgerMenu.OptionsItemsSource>
+                <mah:HamburgerMenuItemCollection>
 
-                </mahapps:HamburgerMenuItemCollection>
-            </mahapps:HamburgerMenu.OptionsItemsSource>
-            
-        </mahapps:HamburgerMenu>
+                    <mah:HamburgerMenuGlyphItem Glyph="&#xE9CE;" Label="About">
+                        <mah:HamburgerMenuGlyphItem.Tag>
+                            <controls:About />
+                        </mah:HamburgerMenuGlyphItem.Tag>
+                    </mah:HamburgerMenuGlyphItem>
+
+                    <mah:HamburgerMenuGlyphItem Glyph="&#xE713;" Label="Settings">
+                        <mah:HamburgerMenuGlyphItem.Tag>
+                            <controls:Settings />
+                        </mah:HamburgerMenuGlyphItem.Tag>
+                    </mah:HamburgerMenuGlyphItem>
+
+                </mah:HamburgerMenuItemCollection>
+            </mah:HamburgerMenu.OptionsItemsSource>
+
+        </mah:HamburgerMenu>
     </DockPanel>
-</Window>
+</mah:MetroWindow>


### PR DESCRIPTION
- Add missing MahApps.Metro resources to App.xaml (necessary)
- Use MahApps MetroWindow instead of original Window (necessary)
- Use Win10 style for MahApps WindowButtonCommands (optional)

![image](https://user-images.githubusercontent.com/658431/44515445-ddcf0b80-a6c2-11e8-832d-f48e1515293b.png)
